### PR TITLE
Add `cargo` installation

### DIFF
--- a/content/mixnet/installation.md
+++ b/content/mixnet/installation.md
@@ -10,7 +10,7 @@ The mixnet code is relatively simple to build and run on Mac OS X and Linux. We 
 ### Requirements
 
 * [Rust](https://www.rust-lang.org/) 1.39 or later, with Cargo. Stable works.
-* on Debian/Ubuntu: `sudo apt install pkg-config build-essential libssl-dev`
+* on Debian/Ubuntu: `sudo apt install pkg-config build-essential libssl-dev cargo`
 
 To download and build:
 


### PR DESCRIPTION
I needed to separately install `cargo` too, so it may be a good idea to add it to the installation packages.