### PR TITLE
new first section for newcomers to nym

### DIFF
--- a/content/run-nym-nodes/mixnodes.md
+++ b/content/run-nym-nodes/mixnodes.md
@@ -12,10 +12,9 @@ The Nym gateway was built in the [building nym](/docs/run-nym-nodes/build-nym/) 
 
 ## Running a mixnode for the first time
 
-The Nym mixnode was built in the [building nym](/docs/run-nym-nodes/build-nym/) section. If you haven't yet built Nym and want to run the code, go there first.
-After your build is finished, nym-mixnode binary will be located in `nym/target/release/` directory. You may then move or copy it to a different place. 
+After your build is finished, the `ym-mixnode` binary will be located in `/path/to/nym/target/release/` directory. You may move or copy it to wherever you wish (for example, you may wish to compile your binaries once locally and then move them to different machines).
 
-Alternativly, you can fetch the binaries from our [releases page](https://github.com/nymtech/nym/releases)
+Alternatively, you can fetch the binaries from our [releases page](https://github.com/nymtech/nym/releases). 
 
 ## Upgrading your mixnode from an earlier version
 

--- a/content/run-nym-nodes/mixnodes.md
+++ b/content/run-nym-nodes/mixnodes.md
@@ -10,6 +10,13 @@ The Nym gateway was built in the [building nym](/docs/run-nym-nodes/build-nym/) 
 
 {{< table_of_contents >}}
 
+## Running a mixnode for the first time
+
+The Nym mixnode was built in the [building nym](/docs/run-nym-nodes/build-nym/) section. If you haven't yet built Nym and want to run the code, go there first.
+After your build is finished, nym-mixnode binary will be located in `nym/target/release/` directory. You may then move or copy it to a different place. 
+
+Alternativly, you can fetch the binaries from our [releases page](https://github.com/nymtech/nym/releases)
+
 ## Upgrading your mixnode from an earlier version
 
 If you have already been running a node on the Nym network v0.9.2 or v0.10.0, grab the new binaries from our [releases page](https://github.com/nymtech/nym/releases) and use the `upgrade` command to upgrade your configs in place.


### PR DESCRIPTION
A lot of people(newcomers to Nym) have been asking me stuff such as:
- where are the binaries after I build Nym?
- how do I get the binaries or build them? 

If my memory serves me right, this section used to be here in the past, although without the exact mixnode binary path. 

I think it is a proper addition for the docs, even if the person has some IT/dev knowledge, they might be compiling a Rust program for the first time and they won't know where the binaries can be unless they really search for them.