### PR TITLE
fix: typo in mixnodes.md

### DIFF
--- a/content/run-nym-nodes/mixnodes.md
+++ b/content/run-nym-nodes/mixnodes.md
@@ -40,7 +40,7 @@ When you run `init`, configuration files are created at `~/.nym/mixnodes/<your-i
 
 The `init` command will refuse to destroy existing mixnode keys.
 
-## Claim your mixnode in Telegram to recieve tokens
+## Claim your mixnode in Telegram to receive tokens
 
 Testnet Finney, which works with version 0.10.x of the Nym mixnode, introduces the concept of "mixnode bonding". Each mixnode operator needs to get tokens, and bond them in our blockchain, in order to enter Testnet Finney.
 


### PR DESCRIPTION
minor fix for typo `recieve` in mixnodes.md