### PR TITLE
Feature/update version 12 01

### DIFF
--- a/docs/develop-with-nym/socks5-client.md
+++ b/docs/develop-with-nym/socks5-client.md
@@ -24,10 +24,10 @@ Which should return a list of all avaliable commands:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (socks5 proxy - version 0.12.0)
+             (socks5 proxy - version 0.12.1)
 
     
-Nym Socks5 Proxy 0.12.0
+Nym Socks5 Proxy 0.12.1
 Nymtech
 A Socks5 localhost proxy that converts incoming messages to Sphinx and sends them to a Nym address
 
@@ -62,15 +62,14 @@ nym-socks5-client init --eth_endpoint <eth_endpoint> --eth_private_key <eth_priv
 
 The `--id` in the example above is a local identifier so that you can name your clients; it is **never** transmitted over the network.
 
-The `--provider` field needs to be filled with the Nym address of a `nym-network-requester` that can make network requests on your behalf. The address in the above example is one that we are currently running for the Sandbox Testnet, but you can also [run your own](/docs/next/run-nym-nodes/nodes/requester/) if you want.
+The `--provider` field needs to be filled with the Nym address of a `nym-network-requester` that can make network requests on your behalf. The address in the above example is one that we are currently running for the Sandbox Testnet, but you can also [run your own](/docs/stable/run-nym-nodes/nodes/requester/) if you want.
 
-The `--testnet-mode` flag is used to initialise your gateway so that it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials will be shared soon. 
-
-The `--end_endpoint` flag must point to either an Ethereum Full Node or an [Infura](https://infura.io/) endpoint, and the `--eth_private_key` is the private key of an Ethereum address. 
+The `--testnet-mode` is currently enabled, it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials (BBCs) will be shared soon. 
 
 :::caution
-Even though the `--testnet-mode` flag removes the need to provide basic bandwidth credentials, you still have to provide the ethereum-related information for the moment.
-::: 
+By default in v0.12.1 `--testnet-mode` is enabled
+:::
+
 
 ### Running the socks5 client
 
@@ -84,4 +83,4 @@ nym-socks5-client run --id <id>
 
 This will start up a SOCKS5 proxy on your local machine, at `localhost:1080`. You can now route application traffic through the Nym Sandbox Testnet! 
 
-To have a look at examples of how to attach some existing applications to your client, please see the [Use External Apps](/docs/next/use-external-apps/index) section. 
+To have a look at examples of how to attach some existing applications to your client, please see the [Use External Apps](/docs/stable/use-external-apps/index) section. 

--- a/docs/develop-with-nym/socks5-client.md
+++ b/docs/develop-with-nym/socks5-client.md
@@ -64,12 +64,6 @@ The `--id` in the example above is a local identifier so that you can name your 
 
 The `--provider` field needs to be filled with the Nym address of a `nym-network-requester` that can make network requests on your behalf. The address in the above example is one that we are currently running for the Sandbox Testnet, but you can also [run your own](/docs/stable/run-nym-nodes/nodes/requester/) if you want.
 
-The `--testnet-mode` is currently enabled, it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials (BBCs) will be shared soon. 
-
-:::caution
-By default in v0.12.1 `--testnet-mode` is enabled
-:::
-
 
 ### Running the socks5 client
 

--- a/docs/develop-with-nym/websocket-client.md
+++ b/docs/develop-with-nym/websocket-client.md
@@ -27,10 +27,10 @@ Which should return a list of all avaliable commands:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (client - version 0.12.0)
+             (client - version 0.12.1)
 
     
-Nym Client 0.12.0
+Nym Client 0.12.1
 Nymtech
 Implementation of the Nym Client
 
@@ -67,16 +67,18 @@ Before you can use the client, you need to initalise a new instance of it. Each 
 Initialising a new client instance can be done with the following command:
 
 ```
-./nym-client init --id <client_id> --eth_endpoint <eth_endpoint> --eth_private_key <eth_private_key> --testnet-mode
+./nym-client init --id <client_id> 
 ```
 
-The `--testnet-mode` flag is used to initialise your gateway so that it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials will be shared soon. 
+The `--id` in the example above is a local identifier so that you can name your clients; it is **never** transmitted over the network.
 
-The `--end_endpoint` flag must point to either an Ethereum Full Node or an [Infura](https://infura.io/) endpoint, and the `--eth_private_key` is the private key of an Ethereum address. 
+The `--testnet-mode` is currently enabled, it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials (BBCs) will be shared soon. 
+
+The `--gateway` parameter is accepted as an optional arg, if you want to use a specific gateway, navigate to `https://sandbox-explorer.nymtech.net/network-components/gateways` and select the `Identity key` then  pass the argument: `--gateway CbxxDmmNCufXSsi7hqUnorchtsqqSLSZp7QfRJ5ugSRA`. Alterantively, not passing this argument will randomly select a  gateway.
 
 :::caution
-Even though the `--testnet-mode` flag removes the need to provide basic bandwidth credentials, you still have to provide the ethereum-related information for the moment.
-::: 
+By default in v0.12.1 `--testnet-mode` is enabled
+:::
 
 When you initalise a client instance, a configuration directory will be generated and stored in `$HOME_DIR/.nym/clients/<client-name>/`.
 

--- a/docs/develop-with-nym/websocket-client.md
+++ b/docs/develop-with-nym/websocket-client.md
@@ -72,13 +72,8 @@ Initialising a new client instance can be done with the following command:
 
 The `--id` in the example above is a local identifier so that you can name your clients; it is **never** transmitted over the network.
 
-The `--testnet-mode` is currently enabled, it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials (BBCs) will be shared soon. 
 
 The `--gateway` parameter is accepted as an optional arg, if you want to use a specific gateway, navigate to `https://sandbox-explorer.nymtech.net/network-components/gateways` and select the `Identity key` then  pass the argument: `--gateway CbxxDmmNCufXSsi7hqUnorchtsqqSLSZp7QfRJ5ugSRA`. Alterantively, not passing this argument will randomly select a  gateway.
-
-:::caution
-By default in v0.12.1 `--testnet-mode` is enabled
-:::
 
 When you initalise a client instance, a configuration directory will be generated and stored in `$HOME_DIR/.nym/clients/<client-name>/`.
 

--- a/docs/nym-apps/network-explorer.md
+++ b/docs/nym-apps/network-explorer.md
@@ -122,7 +122,7 @@ You will most likely want to automate the Explorer-API restarting if your server
 
 ```ini
 [Unit]
-Description=Nym Explorer API (0.12.0)
+Description=Nym Explorer API (0.12.1)
 StartLimitIntervalSec=350
 StartLimitBurst=10
 

--- a/docs/nym-apps/wallet.md
+++ b/docs/nym-apps/wallet.md
@@ -14,20 +14,20 @@ The Nym Desktop Wallet lets you interact with your Nym node and to delegate stak
 
 You can download it for Mac, Windows, or Linux.
 
-[![download nym wallet](/img/docs/download-wallet.png)](https://github.com/nymtech/nym/releases/tag/v0.12.0)
+[![download nym wallet](/img/docs/download-wallet.png)](https://github.com/nymtech/nym/releases/tag/v0.12.1)
 
 ### Bypassing security warnings
 
 On MacOS and Windows, you will see a security warning pop up when you attempt to run the wallet. We are in the process of getting app store keys from Apple and Microsoft so that this doesn't happen. See the section below for details on steps to bypass these. In the meantime, we encourage you to check the authenticity of the your downloads using their file hashes:
 
 * On MacOS 
-`shasum nym-wallet_0.12.0_macos_x64.dmg` should return `639cc6695106e25d7c4cb65b7ebbca1ffbd4c656`  
+`shasum nym-wallet_0.12.1_macos_x64.dmg` should return `639cc6695106e25d7c4cb65b7ebbca1ffbd4c656`  
 
 * On Ubuntu20 
-`shasum nym-wallet_0.12.0_ubuntu_20.04_amd64.AppImage` should return `8f641d54e8143faa9b0c195f21211e412b3221f2`  
+`shasum nym-wallet_0.12.1_ubuntu_20.04_amd64.AppImage` should return `8f641d54e8143faa9b0c195f21211e412b3221f2`  
 
 * On Windows
-`shasum nym-wallet_windows_0.1.0_x64.msi` should return `cd6cd1988fef0b20b81bda9ea0067ac81e56dca8`    
+`shasum nym-wallet_windows_0.12.1_x64.msi` should return `cd6cd1988fef0b20b81bda9ea0067ac81e56dca8`    
 
 
 #### Linux 

--- a/docs/run-nym-nodes/build-nym.md
+++ b/docs/run-nym-nodes/build-nym.md
@@ -46,9 +46,9 @@ git pull # in case you've checked it out before
 
 # Note: the default branch you clone from Github, `develop`, is guaranteed to be
 # broken and incompatible with the running testnet at all times. You *must*
-# `git checkout tags/v0.12.0` in order to join the testnet.
+# `git checkout tags/v0.12.1` in order to join the testnet.
 
-git checkout tags/v0.12.0
+git checkout tags/v0.12.1
 cargo build --release
 ```
 

--- a/docs/run-nym-nodes/build-nym.md
+++ b/docs/run-nym-nodes/build-nym.md
@@ -62,3 +62,7 @@ Quite a bit of stuff gets built. The key working parts are:
 6. the [network explorer api](/docs/next/nym-apps/network-explorer): `explorer-api`
 
 The repository also contains two Typescript applications which aren't built in this process: the [Nym Wallet](docs/next/nym-apps/wallet) and the [Network Explorer UI](docs/next/nym-apps/network-explorer). Both of these can be built by following the instructions on their respective docs pages. 
+
+:::note
+You cannot build from GitHub's .zip or .tar.gz archive files on the releases page - the Nym build scripts automatically include the current git commit hash in the built binary during compilation. Check the code out from github using `git clone` instead. 
+:::

--- a/docs/run-nym-nodes/build-nym.md
+++ b/docs/run-nym-nodes/build-nym.md
@@ -64,5 +64,5 @@ Quite a bit of stuff gets built. The key working parts are:
 The repository also contains two Typescript applications which aren't built in this process: the [Nym Wallet](docs/next/nym-apps/wallet) and the [Network Explorer UI](docs/next/nym-apps/network-explorer). Both of these can be built by following the instructions on their respective docs pages. 
 
 :::note
-You cannot build from GitHub's .zip or .tar.gz archive files on the releases page - the Nym build scripts automatically include the current git commit hash in the built binary during compilation. Check the code out from github using `git clone` instead. 
+You cannot build from GitHub's .zip or .tar.gz archive files on the releases page - the Nym build scripts automatically include the current git commit hash in the built binary during compilation, so the build will fail if you use the archive code (which isn't a Git repository). Check the code out from github using `git clone` instead. 
 :::

--- a/docs/run-nym-nodes/nodes/gateways.md
+++ b/docs/run-nym-nodes/nodes/gateways.md
@@ -41,7 +41,7 @@ Which should return:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (gateway - version 0.12.0)
+             (gateway - version 0.12.1)
 
 
 
@@ -64,31 +64,14 @@ Which will return the following:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (gateway - version 0.12.0)
+             (gateway - version 0.12.1)
 
     
 nym-gateway-init 
 Initialise the gateway
 
 USAGE:
-    nym-gateway init [FLAGS] [OPTIONS] --eth_endpoint <eth_endpoint> --host <host> --id <id> --mnemonic <mnemonic> --wallet-address <wallet-address>
-
-FLAGS:
-    -h, --help            Prints help information
-        --testnet-mode    Set this gateway to work in a testnet mode that would allow clients to bypass bandwidth
-                          credential requirement
-    -V, --version         Prints version information
-
-OPTIONS:
-        --announce-host <announce-host>      The host that will be reported to the directory server
-        --clients-port <clients-port>        The port on which the gateway will be listening for clients gateway-
-                                             requests
-        --datastore <datastore>              Path to sqlite database containing all gateway persistent data
-        --eth_endpoint <eth_endpoint>        URL of an Ethereum full node that we want to use for getting bandwidth
-                                             tokens from ERC20 tokens
-        --host <host>                        The custom host on which the gateway will be running for receiving sphinx
-                                             packets
-        --id <id>                            Id of the gateway we want to create config for.
+    nym-gateway init [FLAGS] [OPTIONS        Id of the gateway we want to create config for.
         --mix-port <mix-port>                The port on which the gateway will be listening for sphinx packets
         --mnemonic <mnemonic>                Cosmos wallet mnemonic
         --validator-apis <validator-apis>    Comma separated list of endpoints of the validators APIs
@@ -101,17 +84,15 @@ OPTIONS:
 The following command returns a gateway on your current IP with the `id` of `supergateway`:
 
 ```
- ./nym-gateway init --id supergateway --host $(curl ifconfig.me) --testnet-mode --eth_endpoint <infura_endpoint> --mnemonic <account_mnemonic> --wallet-address <wallet_address>
+ ./nym-gateway init --id supergateway --host $(curl ifconfig.me) --wallet-address <wallet_address>
 ```
 
 The `$(curl ifconfig.me)` command above returns your IP automatically using an external service. Alternatively, you can enter your IP manually wish. If you do this, remember to enter your IP **without** any port information.
 
-The `--testnet-mode` flag is used to initialise your gateway so that it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials (BBCs) will be shared soon. 
-
-Finally, the `--end_endpoint` flag must point to an [Infura](https://infura.io/) endpoint, and the `--mnemonic` is the mneomic of your existing Sandbox Testnet address. 
+The `--testnet-mode` is currently enabled, it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials (BBCs) will be shared soon. 
 
 :::caution
-Even though the `--testnet-mode` flag removes the need to provide basic bandwidth credentials, you still have to provide the ethereum-related information for the moment.
+By default in v0.12.1 `--testnet-mode` is enabled behind the `init` of the gateway
 :::
 
 Gateways **must** also be capable of addressing IPv6, which is something that is hard to come by with many ISPs. Running a gateway from behind your router will be tricky because of this, and we strongly recommend to run your gateway on a VPS. Additional to IPv6 connectivity, this will help maintain better uptime and connectivity.
@@ -138,7 +119,7 @@ Results in:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (gateway - version 0.12.0)
+             (gateway - version 0.12.1)
 
 
 Starting gateway supergateway...
@@ -179,12 +160,12 @@ This prints various bits of information about your node:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (gateway - version 0.12.0)
+             (gateway - version 0.12.1)
 
     
 Nym Mixnet Gateway 
 Build Timestamp:    2021-12-17T16:59:54.243831464+00:00
-Build Version:      0.12.0
+Build Version:      0.12.1
 Commit SHA:         96aa814a6106d6d5bbc1245cdc21b5b554d47b5f
 Commit Date:        2021-12-17T14:30:04+00:00
 Commit Branch:      detached HEAD
@@ -225,7 +206,7 @@ Although it's not totally necessary, it's useful to have the gateway automatical
 
 ```ini
 [Unit]
-Description=Nym Gateway (0.12.0)
+Description=Nym Gateway (0.12.1)
 StartLimitInterval=350
 StartLimitBurst=10
 
@@ -281,3 +262,4 @@ All gateway-specific port configuration can be found in `$HOME/.nym/gateways/<yo
 |--------------|---------------------------|
 | 1789         | Listen for Mixnet traffic |
 | 9000         | Listen for Client traffic |
+

--- a/docs/run-nym-nodes/nodes/gateways.md
+++ b/docs/run-nym-nodes/nodes/gateways.md
@@ -71,7 +71,20 @@ nym-gateway-init
 Initialise the gateway
 
 USAGE:
-    nym-gateway init [FLAGS] [OPTIONS        Id of the gateway we want to create config for.
+    nym-gateway init [FLAGS]  [OPTIONS] --host <host> --id <id> --wallet-address <wallet-address>       
+
+FLAGS:
+    -h, --help            Prints help information
+
+    -V, --version         Prints version information
+
+OPTIONS:
+        --announce-host <announce-host>      The host that will be reported to the directory server
+        --clients-port <clients-port>        The port on which the gateway will be listening for clients gateway-
+                                             requests
+        --datastore <datastore>              Path to sqlite database containing all gateway persistent data
+        --host <host>                        The custom host on which the gateway will be running for receiving sphinx packets
+        --id <id>                            Id of the gateway we want to create config for.
         --mix-port <mix-port>                The port on which the gateway will be listening for sphinx packets
         --mnemonic <mnemonic>                Cosmos wallet mnemonic
         --validator-apis <validator-apis>    Comma separated list of endpoints of the validators APIs

--- a/docs/run-nym-nodes/nodes/gateways.md
+++ b/docs/run-nym-nodes/nodes/gateways.md
@@ -102,12 +102,6 @@ The following command returns a gateway on your current IP with the `id` of `sup
 
 The `$(curl ifconfig.me)` command above returns your IP automatically using an external service. Alternatively, you can enter your IP manually wish. If you do this, remember to enter your IP **without** any port information.
 
-The `--testnet-mode` is currently enabled, it doesn't require bandwidth credentials for data sent through the mixnet by clients. This functionality is still in active development, and updates regarding Basic Bandwidth Credentials (BBCs) will be shared soon. 
-
-:::caution
-By default in v0.12.1 `--testnet-mode` is enabled behind the `init` of the gateway
-:::
-
 Gateways **must** also be capable of addressing IPv6, which is something that is hard to come by with many ISPs. Running a gateway from behind your router will be tricky because of this, and we strongly recommend to run your gateway on a VPS. Additional to IPv6 connectivity, this will help maintain better uptime and connectivity.
 
 Remember to bond your node via the Nym wallet, which can be downloaded [here](https://github.com/nymtech/nym/releases/). This is required for the blockchain to recognize your node and its software version, and include your gateway in the mixnet. 

--- a/docs/run-nym-nodes/nodes/gateways.md
+++ b/docs/run-nym-nodes/nodes/gateways.md
@@ -71,7 +71,7 @@ nym-gateway-init
 Initialise the gateway
 
 USAGE:
-    nym-gateway init [FLAGS]  [OPTIONS] --host <host> --id <id> --wallet-address <wallet-address>       
+    nym-gateway init [FLAGS]  [OPTIONS] --host <host> --id <id> --wallet-address <wallet-address>
 
 FLAGS:
     -h, --help            Prints help information

--- a/docs/run-nym-nodes/nodes/mixnodes.md
+++ b/docs/run-nym-nodes/nodes/mixnodes.md
@@ -22,7 +22,7 @@ For those not able to immediately get involved, please look into [delegated stak
 If you **do** delegate your `NYMT` to others and shut down your node, remember to **save the keys located in `$HOME/.nym` in case you want to run a node in the future**
 :::
 
-Even you have already been running a node on the Milhon testnet, **you must do a clean install of the v0.12.0 `nym-mixnode` binary**. 
+Even you have already been running a node on the Milhon testnet, **you must do a clean install of the v0.12.1 `nym-mixnode` binary**. 
 
 You can either build the repository from source, or grab the new binaries from our [releases page](https://github.com/nymtech/nym/releases). 
 
@@ -43,10 +43,10 @@ Which should return a list of all avaliable commands:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (mixnode - version 0.12.0)
+             (mixnode - version 0.12.1)
 
     
-Nym Mixnode 0.12.0
+Nym Mixnode 0.12.1
 Nymtech
 Implementation of a Loopix-based Mixnode
 
@@ -59,7 +59,7 @@ FLAGS:
 
 SUBCOMMANDS:
     describe        Describe your mixnode and tell people why they should delegate stake to you
-    help            Prints this message or the help of the given subcommand(s)
+    help            Prints this message or the help of the given subcomman  d(s)
     init            Initialise the mixnode
     node-details    Show details of this mixnode
     run             Starts the mixnode
@@ -83,7 +83,7 @@ Which will return:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (mixnode - version 0.12.0)
+             (mixnode - version 0.12.1)
 
 
 nym-mixnode-init
@@ -145,7 +145,7 @@ Which should return a nice clean startup:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (mixnode - version 0.12.0)
+             (mixnode - version 0.12.1)
 
 
 Starting mixnode winston-smithnode...
@@ -158,8 +158,8 @@ Identity Key: 733KdRDp9jyiTKvK6U1AGbSg8uEb7TUN8HtTEvNACTKq
 Sphinx Key: BVQxKYbGmnnESLUkzmpLVNxQkqoeuCYro7EL5sfqUkxN
 Owner Signature: 4eY6PEUEPMWZSBc5dSksrWWQrtCcejgPptNnNbM7MWaFKru7LzSNib8FtZdqcUGRvsySu44znPZx6QmU1snd1Zov
 Host: 1.2.3.4 (bind address: 127.0.0.1)
-Version: 0.12.0
-Mix Port: 1789, Verloc port: 0.12.0, Http Port: 8000
+Version: 0.12.1
+Mix Port: 1789, Verloc port: 0.12.1, Http Port: 8000
 
 You are bonding to wallet address: nymt1z9egw0knv47nmur0p8vk4rcx59h9gg4zuxrrr9
 
@@ -196,7 +196,7 @@ Which will output something like this:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (mixnode - version 0.12.0)
+             (mixnode - version 0.12.1)
 
 
 name: winston-smithnode
@@ -220,15 +220,15 @@ You can always check the details of your mixnode with the `node-details` command
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (mixnode - version 0.12.0)
+             (mixnode - version 0.12.1)
 
 
 Identity Key: 733KdRDp9jyiTKvK6U1AGbSg8uEb7TUN8HtTEvNACTKq
 Sphinx Key: BVQxKYbGmnnESLUkzmpLVNxQkqoeuCYro7EL5sfqUkxN
 Owner Signature: 4eY6PEUEPMWZSBc5dSksrWWQrtCcejgPptNnNbM7MWaFKru7LzSNib8FtZdqcUGRvsySu44znPZx6QmU1snd1Zov
 Host: 1.2.3.4 (bind address: 127.0.0.1)
-Version: 0.12.0
-Mix Port: 1789, Verloc port: 0.12.0, Http Port: 8000
+Version: 0.12.1
+Mix Port: 1789, Verloc port: 0.12.1, Http Port: 8000
 
 You are bonding to wallet address: nymt1z9egw0knv47nmur0p8vk4rcx59h9gg4zuxrrr9
 ```
@@ -264,7 +264,7 @@ It's useful to have the mixnode automatically start at system boot time. Here's 
 
 ```ini
 [Unit]
-Description=Nym Mixnode (0.12.0)
+Description=Nym Mixnode (0.12.1)
 StartLimitInterval=350
 StartLimitBurst=10
 

--- a/docs/run-nym-nodes/nodes/mixnodes.md
+++ b/docs/run-nym-nodes/nodes/mixnodes.md
@@ -59,7 +59,7 @@ FLAGS:
 
 SUBCOMMANDS:
     describe        Describe your mixnode and tell people why they should delegate stake to you
-    help            Prints this message or the help of the given subcomman  d(s)
+    help            Prints this message or the help of the given subcommand(s)
     init            Initialise the mixnode
     node-details    Show details of this mixnode
     run             Starts the mixnode

--- a/docs/run-nym-nodes/nodes/requester.md
+++ b/docs/run-nym-nodes/nodes/requester.md
@@ -36,7 +36,7 @@ Which should return:
      |_| |_|\__, |_| |_| |_|
             |___/
 
-             (client - version 0.12.0)
+             (client - version 0.12.1)
 
     
 Initialising client...
@@ -53,7 +53,7 @@ Now create a service file at `/etc/systemd/system/nym-client.service`:
 
 ```
 [Unit]
-Description=Nym Client (0.12.0)
+Description=Nym Client (0.12.1)
 StartLimitInterval=350
 StartLimitBurst=10
 
@@ -106,7 +106,7 @@ Now stop that process with `CTRL-C`, and create a service file for the requester
 
 ```
 [Unit]
-Description=Nym Client (0.12.0)
+Description=Nym Client (0.12.1)
 StartLimitInterval=350
 StartLimitBurst=10
 

--- a/docs/run-nym-nodes/nodes/troubleshooting.md
+++ b/docs/run-nym-nodes/nodes/troubleshooting.md
@@ -5,6 +5,25 @@ hide_title: false
 title: Mixnodes FAQ
 ---
 
+### I am trying to build from the GitHub archive files and the build fails
+
+GitHub automatically includes .zip and tar.gz files of the Nym repository in its release. You cannot extract these and build - you'll see something like this:
+
+```
+  process didn't exit successfully: `/build/nym/src/nym-0.12.0/target/release/build/nym-socks5-client-c1d0f76a8c7d7e9a/build-script-build` (exit status: 101)
+  --- stderr
+  thread 'main' panicked at 'failed to extract build metadata: could not find repository from '/build/nym/src/nym-0.12.0/clients/socks5'; class=Repository (6); code=NotFound (-3)', clients/socks5/build.rs:7:31
+  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+warning: build failed, waiting for other jobs to finish...
+error: build failed
+```
+
+Why does this happen? 
+
+We have scripts which automatically include the Git commit hash and Git tag in the binary for easier debugging later. If you download a .zip and try building from that, it's not a Git repository and build will fail as above.
+
+
+
 ### How can I tell my node is up and running and mixing traffic?
 
 First of all check the 'Mixnodes' section of the testnet [dashboard](https://sandbox-explorer.nymtech.net/) and enter your **identity key**, and you should see your node. Alternatively you can check the [leaderboard interface](https://nodes.guru/nym/leaderboard) created by community member Evgeny Garanin from [Nodes Guru](https://nodes.guru).

--- a/docs/run-nym-nodes/nodes/troubleshooting.md
+++ b/docs/run-nym-nodes/nodes/troubleshooting.md
@@ -22,8 +22,6 @@ Why does this happen?
 
 We have scripts which automatically include the Git commit hash and Git tag in the binary for easier debugging later. If you download a .zip and try building from that, it's not a Git repository and build will fail as above.
 
-
-
 ### How can I tell my node is up and running and mixing traffic?
 
 First of all check the 'Mixnodes' section of the testnet [dashboard](https://sandbox-explorer.nymtech.net/) and enter your **identity key**, and you should see your node. Alternatively you can check the [leaderboard interface](https://nodes.guru/nym/leaderboard) created by community member Evgeny Garanin from [Nodes Guru](https://nodes.guru).

--- a/docs/run-nym-nodes/nodes/troubleshooting.md
+++ b/docs/run-nym-nodes/nodes/troubleshooting.md
@@ -10,9 +10,9 @@ title: Mixnodes FAQ
 GitHub automatically includes .zip and tar.gz files of the Nym repository in its release. You cannot extract these and build - you'll see something like this:
 
 ```
-  process didn't exit successfully: `/build/nym/src/nym-0.12.0/target/release/build/nym-socks5-client-c1d0f76a8c7d7e9a/build-script-build` (exit status: 101)
+  process didn't exit successfully: `/build/nym/src/nym-0.12.1/target/release/build/nym-socks5-client-c1d0f76a8c7d7e9a/build-script-build` (exit status: 101)
   --- stderr
-  thread 'main' panicked at 'failed to extract build metadata: could not find repository from '/build/nym/src/nym-0.12.0/clients/socks5'; class=Repository (6); code=NotFound (-3)', clients/socks5/build.rs:7:31
+  thread 'main' panicked at 'failed to extract build metadata: could not find repository from '/build/nym/src/nym-0.12.1/clients/socks5'; class=Repository (6); code=NotFound (-3)', clients/socks5/build.rs:7:31
   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 warning: build failed, waiting for other jobs to finish...
 error: build failed

--- a/docs/run-nym-nodes/nodes/validators.md
+++ b/docs/run-nym-nodes/nodes/validators.md
@@ -138,7 +138,7 @@ git clone https://github.com/nymtech/nym.git
 cd nym
 git reset --hard   # in case you made any changes on your branch
 git pull           # in case you've checked it out before
-git checkout tags/v0.12.0
+git checkout tags/v0.12.1
 ```
 
 Inside the `validator` directory you will find the precompiled binaries to use.
@@ -357,7 +357,7 @@ You will most likely want to automate your validator restarting if your server r
 
 ```ini
 [Unit]
-Description=Nymd (0.12.0)
+Description=Nymd (0.12.1)
 StartLimitInterval=350
 StartLimitBurst=10
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -118,12 +118,12 @@ module.exports = {
           lastVersion: undefined,
           versions: {
             current: {
-              label: 'Next (in progress)',
+              label: 'v0.12.1',
               path: 'next',
               banner: 'unreleased',
             },
             'stable': {
-              label: 'v0.12.0 (stable)',
+              label: 'v0.12.0',
               path: 'stable',
               banner: 'none',
             },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,7 +120,7 @@ module.exports = {
             current: {
               label: 'v0.12.1',
               path: 'next',
-              banner: 'unreleased',
+              banner: 'none',
             },
             'stable': {
               label: 'v0.12.0',

--- a/versioned_docs/version-stable/run-nym-nodes/build-nym.md
+++ b/versioned_docs/version-stable/run-nym-nodes/build-nym.md
@@ -62,3 +62,7 @@ Quite a bit of stuff gets built. The key working parts are:
 6. the [network explorer api](/docs/stable/nym-apps/network-explorer): `explorer-api`
 
 The repository also contains two Typescript applications which aren't built in this process: the [Nym Wallet](docs/stable/nym-apps/wallet) and the [Network Explorer UI](docs/stable/nym-apps/network-explorer). Both of these can be built by following the instructions on their respective docs pages. 
+
+:::note
+You cannot build from GitHub's .zip or .tar.gz archive files on the releases page - the Nym build scripts automatically include the current git commit hash in the built binary during compilation. Check the code out from github using `git clone` instead. 
+:::

--- a/versioned_docs/version-stable/run-nym-nodes/nodes/troubleshooting.md
+++ b/versioned_docs/version-stable/run-nym-nodes/nodes/troubleshooting.md
@@ -357,3 +357,20 @@ You don't have to do any additional configuration for your node to implement thi
 The fastest way to reach one of us or get a help from the community, visit our [Telegram help chat](https://t.me/nymchan_help_chat).
 
 For more tech heavy questions join our Keybase channel. Get Keybase [here](https://keybase.io/), then click Teams -> Join a team. Type nymtech.friends into the team name and hit continue. For general chat, hang out in the #general channel. Our development takes places in the #dev channel.
+
+### I am trying to build my mixnode from the GitHub archive files and the build fails
+
+GitHub automatically includes .zip and tar.gz files of the Nym repository in its release. You cannot extract these and build - you'll see something like this:
+
+```
+  process didn't exit successfully: `/build/nym/src/nym-0.12.0/target/release/build/nym-socks5-client-c1d0f76a8c7d7e9a/build-script-build` (exit status: 101)
+  --- stderr
+  thread 'main' panicked at 'failed to extract build metadata: could not find repository from '/build/nym/src/nym-0.12.0/clients/socks5'; class=Repository (6); code=NotFound (-3)', clients/socks5/build.rs:7:31
+  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+warning: build failed, waiting for other jobs to finish...
+error: build failed
+```
+
+Why does this happen? 
+
+We have scripts which automatically include the Git commit hash and Git tag in the binary for easier debugging later. If you download a .zip and try building from that, it's not a Git repository and build will fail as above. Use `git clone` instead. 


### PR DESCRIPTION
- We currently have two stable builds
- One with the eth params and now one without 
- Updated the docs to have both v0.12.0 and v0.12.01 running in parallel
- Removed the version name `unreleased`