### PR TITLE
Fix validator docs

### DIFF
--- a/docs/run-nym-nodes/nodes/validators.md
+++ b/docs/run-nym-nodes/nodes/validators.md
@@ -111,7 +111,7 @@ git clone https://github.com/CosmWasm/wasmd.git
 cd wasmd
 git checkout ${WASMD_VERSION}
 mkdir build
-go build -o ./build/nymd -mod=readonly -tags "netgo,ledger" -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=nymd -X github.com/cosmos/cosmos-sdk/version.AppName=nymd -X github.com/CosmWasm/wasmd/app.NodeDir=.nymd -X github.com/cosmos/cosmos-sdk/version.Version=${WASMD_VERSION} -X github.com/cosmos/cosmos-sdk/version.Commit=4ffba672739a41d395827b78cb610f4a51eea83c -X github.com/CosmWasm/wasmd/app.Bech32Prefix=${BECH32_PREFIX} -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger"' -trimpath ./cmd/wasmd
+go build -o ./build/nymd -mod=readonly -tags "netgo,ledger" -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name=nymd -X github.com/cosmos/cosmos-sdk/version.AppName=nymd -X github.com/CosmWasm/wasmd/app.NodeDir=.nymd -X github.com/cosmos/cosmos-sdk/version.Version=${WASMD_VERSION} -X github.com/cosmos/cosmos-sdk/version.Commit=4ffba672739a41d395827b78cb610f4a51eea83c -X github.com/CosmWasm/wasmd/app.Bech32Prefix=${BECH32_PREFIX} -X \"github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger\"" -trimpath ./cmd/wasmd
 ```
 
 At this point, you will have a copy of the `nymd` binary in your `build/` directory. Test that it's compiled properly by running:
@@ -187,9 +187,18 @@ Prerequisites:
 
 Choose a name for your validator and use it in place of `yourname` in the following command:
 
-```
-nymd init yourname --chain-id nym-sandbox
-```
+<Tabs groupId="nym-network">
+  <TabItem value="sandbox" label="Sandbox (Testnet)">
+    <pre>
+      nymd init <yourname> --chain-id=nym-sandbox 
+    </pre>
+  </TabItem>
+    <TabItem value="mainnet" label="Nyx (Mainnet)">
+    <pre>
+      nymd init <yourname> --chain-id=nym 
+    </pre>
+  </TabItem>
+</Tabs>
 
 :::caution
 `nymd init` generates `priv_validator_key.json` and `node_key.json`.  
@@ -243,7 +252,7 @@ there is no way to deterministically (re)generate this key using `nymd`.
       cors_allowed_origins = ["*"] 
     </pre>
     <pre>
-      persistent_peers = "0a54f8f793427d3269b7a1d552bd11214f37990e@sandbox-validator.nymtech.net:26656" 
+      persistent_peers = "0a54f8f793427d3269b7a1d552bd11214f37990e@nym-mainnet.commodum.io:26656" 
     </pre>
     <pre>
       create_empty_blocks = false 


### PR DESCRIPTION
This PR fixes the following: 

- Command for compilation
- `init` command. Added a tab structure for `nymd init` as it needs `--chain-id` _(couldn't test this locally, please verify)_
- Node address for the mainnet validator