### PR TITLE
Feature/contract initial docs

### DIFF
--- a/docs/smart-contracts/mixnet.md
+++ b/docs/smart-contracts/mixnet.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Mixnet Contract
+description: ""
+hide_title: false
+title: Mixnet Contract
+---
+
+

--- a/docs/smart-contracts/mixnet.md
+++ b/docs/smart-contracts/mixnet.md
@@ -1,8 +1,35 @@
 ---
 sidebar_label: Mixnet Contract
-description: ""
+description: "information on the core functionality and configuration of the mixnet smart contract"
 hide_title: false
 title: Mixnet Contract
 ---
+
+The Mixnet smart contract is a core piece of the Nym system, functioning as the mixnet directory and keeping track of delegations and rewards: the core functionality required by an incentivised mixnet. You can find the code and build instructions [here](https://github.com/nymtech/nym/tree/release/v1.1.0/contracts/mixnet).
+
+### Functionality 
+The Mixnet contract has multiple functions: 
+**TODO ADD LINKS TO RELEVANT BITS OF CODE IN BULLETPOINTS**
+* storing bonded mix node and gateway information (and removing this on unbonding).
+* providing the network-topology to the (cached) validator API endpoint used by clients on startup for routing information. 
+* storing delegation and bond amounts.
+* storing reward amounts. 
+
+The addresses of deployed smart contracts can be found in the [`network-defaults`](https://github.com/nymtech/nym/blob/release/v1.1.0/common/network-defaults/src/mainnet.rs) directory of the codebase alongside other network default values.
+
+### Interacting with the contract 
+There are two ways to interact with the deployed smart contract: 
+* the `nym-cli` tool
+* the `nyxd` binary
+
+#### Nym-cli tool (recommended in most cases) 
+The `nym-cli` tool is a binary offering a simple interface for interacting with deployed smart contract (for instance, bonding and unbonding a mix node from the CLI), as well as creating and managing accounts and keypairs, sending tokens, and querying the blockchain. 
+
+Instructions on how to do so can be found on the [`nym-cli` docs page](/docs/next/nym-cli).
+
+#### Nyxd binary 
+The `nyxd` binary, although more complex to compile and use, offers the full range of commands availiable to users of CosmosSDK chains. Use this if you are (e.g.) wanting to perform more granular queries about transactions from the CLI. 
+
+Instructions on how to do so can be found on the [`nyxd` docs page](/docs/next/run-nym-nodes/nodes/rpc-node).
 
 

--- a/docs/smart-contracts/mixnet.md
+++ b/docs/smart-contracts/mixnet.md
@@ -9,7 +9,6 @@ The Mixnet smart contract is a core piece of the Nym system, functioning as the 
 
 ### Functionality 
 The Mixnet contract has multiple functions: 
-**TODO ADD LINKS TO RELEVANT BITS OF CODE IN BULLETPOINTS**
 * storing bonded mix node and gateway information (and removing this on unbonding).
 * providing the network-topology to the (cached) validator API endpoint used by clients on startup for routing information. 
 * storing delegation and bond amounts.

--- a/docs/smart-contracts/mixnet.md
+++ b/docs/smart-contracts/mixnet.md
@@ -29,6 +29,6 @@ Instructions on how to do so can be found on the [`nym-cli` docs page](/docs/nex
 #### Nyxd binary 
 The `nyxd` binary, although more complex to compile and use, offers the full range of commands availiable to users of CosmosSDK chains. Use this if you are (e.g.) wanting to perform more granular queries about transactions from the CLI. 
 
-Instructions on how to do so can be found on the [`nyxd` docs page](/docs/next/run-nym-nodes/nodes/rpc-node).
+You can use the instructions on how to do this on from the [`gaiad` docs page](https://hub.cosmos.network/main/delegators/delegator-guide-cli.html#querying-the-state).
 
 

--- a/docs/smart-contracts/overview.md
+++ b/docs/smart-contracts/overview.md
@@ -5,7 +5,7 @@ hide_title: false
 title: Overview
 ---
 
-The Nyx blockchain **TODO add link to explorer** is based on [CosmWasm](https://cosmwasm.com/). It allows users to code smart contracts in a safe subset of the Rust programming language, easily export them to WebAssembly, and upload them to the blockchain. 
+The Nyx blockchain is based on [CosmWasm](https://cosmwasm.com/). It allows users to code smart contracts in a safe subset of the Rust programming language, easily export them to WebAssembly, and upload them to the blockchain. Information about the chain can be found on the [Nyx blockchain explorer](https://nym.explorers.guru/). 
 
 There are currently two smart contracts on the Nyx chain: 
 * the [Mixnet contract](/docs/next/smart-contracts/mixnet) which manages the network topology of the mixnet, tracking delegations and rewarding. 

--- a/docs/smart-contracts/overview.md
+++ b/docs/smart-contracts/overview.md
@@ -5,4 +5,12 @@ hide_title: false
 title: Overview
 ---
 
-lorem ipsum
+The Nyx blockchain **TODO add link to explorer** is based on [CosmWasm](https://cosmwasm.com/). It allows users to code smart contracts in a safe subset of the Rust programming language, easily export them to WebAssembly, and upload them to the blockchain. 
+
+There are currently two smart contracts on the Nyx chain: 
+* the [Mixnet contract](/docs/next/smart-contracts/mixnet) which manages the network topology of the mixnet, tracking delegations and rewarding. 
+* the [Vesting contract](/docs/next/smart-contracts/vesting) which manages `NYM` token vesting functionality.  
+
+:::note
+Users will soon be able to create and upload their own CosmWasm smart contracts to Nyx and take advantage of applications such as [Coconut](/docs/next/coconut) - more to be announced regarding this very soon.
+:::

--- a/docs/smart-contracts/overview.md
+++ b/docs/smart-contracts/overview.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Overview
+description: "Overview of the Nym CosmWasm smart contracts"
+hide_title: false
+title: Overview
+---
+
+lorem ipsum

--- a/docs/smart-contracts/vesting.md
+++ b/docs/smart-contracts/vesting.md
@@ -27,6 +27,6 @@ Instructions on how to do so can be found on the [`nym-cli` docs page](/docs/nex
 #### Nyxd binary 
 The `nyxd` binary, although more complex to compile and use, offers the full range of commands availiable to users of CosmosSDK chains. Use this if you are (e.g.) wanting to perform more granular queries about transactions from the CLI. 
 
-Instructions on how to do so can be found on the [`nyxd` docs page](/docs/next/run-nym-nodes/nodes/rpc-node).
+You can use the instructions on how to do this on from the [`gaiad` docs page](https://hub.cosmos.network/main/delegators/delegator-guide-cli.html#querying-the-state).
 
 

--- a/docs/smart-contracts/vesting.md
+++ b/docs/smart-contracts/vesting.md
@@ -1,8 +1,28 @@
----
-sidebar_label: Vesting Contract
-description: ""
+--- 
+sidebar_label: Vesting Contract 
+description: "information on the core functionality and configuration of the vesting smart contract"
 hide_title: false
 title: Vesting Contract
 ---
 
-lorem ipsum
+### Functionality 
+// **TODO** little bit of Functionality breakdown 
+
+The addresses of deployed smart contracts can be found in the [`network-defaults`](https://github.com/nymtech/nym/blob/release/v1.1.0/common/network-defaults/src/mainnet.rs) directory of the codebase alongside other network default values.
+
+### Interacting with the contract 
+There are two ways to interact with the deployed smart contract: 
+* the `nym-cli` tool
+* the `nyxd` binary
+
+#### Nym-cli tool (recommended in most cases) 
+The `nym-cli` tool is a binary offering a simple interface for interacting with deployed smart contract (for instance, bonding and unbonding a mix node from the CLI), as well as creating and managing accounts and keypairs, sending tokens, and querying the blockchain. 
+
+Instructions on how to do so can be found on the [`nym-cli` docs page](/docs/next/nym-cli).
+
+#### Nyxd binary 
+The `nyxd` binary, although more complex to compile and use, offers the full range of commands availiable to users of CosmosSDK chains. Use this if you are (e.g.) wanting to perform more granular queries about transactions from the CLI. 
+
+Instructions on how to do so can be found on the [`nyxd` docs page](/docs/next/run-nym-nodes/nodes/rpc-node).
+
+

--- a/docs/smart-contracts/vesting.md
+++ b/docs/smart-contracts/vesting.md
@@ -5,8 +5,12 @@ hide_title: false
 title: Vesting Contract
 ---
 
+The vesting contract allows for the creation of vesting accounts, allowing `NYM` tokens to vest over time, and for users to minimally interact with the Mixnet using their unvested tokens. You can find the code and build instructions [here](https://github.com/nymtech/nym/tree/release/v1.1.0/contracts/vesting). 
+
 ### Functionality 
-// **TODO** little bit of Functionality breakdown 
+The Vesting contract has multiple functions:
+* Creating and storing vesting `NYM` token vesting accounts.
+* Interacting with the Mixnet using vesting (i.e. non-transferable) tokens, allowing users to delegate their unvested tokens. 
 
 The addresses of deployed smart contracts can be found in the [`network-defaults`](https://github.com/nymtech/nym/blob/release/v1.1.0/common/network-defaults/src/mainnet.rs) directory of the codebase alongside other network default values.
 

--- a/docs/smart-contracts/vesting.md
+++ b/docs/smart-contracts/vesting.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Vesting Contract
+description: ""
+hide_title: false
+title: Vesting Contract
+---
+
+lorem ipsum

--- a/sidebars.js
+++ b/sidebars.js
@@ -70,6 +70,16 @@ module.exports = {
       "run-nym-nodes/network-rewards",
       ],
     },
+    {
+        type: "category", 
+        label: "Smart Contracts", 
+        collapsed: true, 
+        items: [
+            "smart-contracts/overview",
+            "smart-contracts/mixnet", 
+            "smart-contracts/vesting"
+        ],
+    },
     "wallet",
     "nym-cli",
     "coconut",

--- a/versioned_docs/version-stable/smart-contracts/mixnet.md
+++ b/versioned_docs/version-stable/smart-contracts/mixnet.md
@@ -1,0 +1,34 @@
+---
+sidebar_label: Mixnet Contract
+description: "information on the core functionality and configuration of the mixnet smart contract"
+hide_title: false
+title: Mixnet Contract
+---
+
+The Mixnet smart contract is a core piece of the Nym system, functioning as the mixnet directory and keeping track of delegations and rewards: the core functionality required by an incentivised mixnet. You can find the code and build instructions [here](https://github.com/nymtech/nym/tree/release/v1.1.0/contracts/mixnet).
+
+### Functionality 
+The Mixnet contract has multiple functions: 
+* storing bonded mix node and gateway information (and removing this on unbonding).
+* providing the network-topology to the (cached) validator API endpoint used by clients on startup for routing information. 
+* storing delegation and bond amounts.
+* storing reward amounts. 
+
+The addresses of deployed smart contracts can be found in the [`network-defaults`](https://github.com/nymtech/nym/blob/release/v1.1.0/common/network-defaults/src/mainnet.rs) directory of the codebase alongside other network default values.
+
+### Interacting with the contract 
+There are two ways to interact with the deployed smart contract: 
+* the `nym-cli` tool
+* the `nyxd` binary
+
+#### Nym-cli tool (recommended in most cases) 
+The `nym-cli` tool is a binary offering a simple interface for interacting with deployed smart contract (for instance, bonding and unbonding a mix node from the CLI), as well as creating and managing accounts and keypairs, sending tokens, and querying the blockchain. 
+
+Instructions on how to do so can be found on the [`nym-cli` docs page](/docs/next/nym-cli).
+
+#### Nyxd binary 
+The `nyxd` binary, although more complex to compile and use, offers the full range of commands availiable to users of CosmosSDK chains. Use this if you are (e.g.) wanting to perform more granular queries about transactions from the CLI. 
+
+You can use the instructions on how to do this on from the [`gaiad` docs page](https://hub.cosmos.network/main/delegators/delegator-guide-cli.html#querying-the-state).
+
+

--- a/versioned_docs/version-stable/smart-contracts/overview.md
+++ b/versioned_docs/version-stable/smart-contracts/overview.md
@@ -1,0 +1,16 @@
+---
+sidebar_label: Overview
+description: "Overview of the Nym CosmWasm smart contracts"
+hide_title: false
+title: Overview
+---
+
+The Nyx blockchain is based on [CosmWasm](https://cosmwasm.com/). It allows users to code smart contracts in a safe subset of the Rust programming language, easily export them to WebAssembly, and upload them to the blockchain. Information about the chain can be found on the [Nyx blockchain explorer](https://nym.explorers.guru/). 
+
+There are currently two smart contracts on the Nyx chain: 
+* the [Mixnet contract](/docs/next/smart-contracts/mixnet) which manages the network topology of the mixnet, tracking delegations and rewarding. 
+* the [Vesting contract](/docs/next/smart-contracts/vesting) which manages `NYM` token vesting functionality.  
+
+:::note
+Users will soon be able to create and upload their own CosmWasm smart contracts to Nyx and take advantage of applications such as [Coconut](/docs/next/coconut) - more to be announced regarding this very soon.
+:::

--- a/versioned_docs/version-stable/smart-contracts/vesting.md
+++ b/versioned_docs/version-stable/smart-contracts/vesting.md
@@ -1,0 +1,32 @@
+--- 
+sidebar_label: Vesting Contract 
+description: "information on the core functionality and configuration of the vesting smart contract"
+hide_title: false
+title: Vesting Contract
+---
+
+The vesting contract allows for the creation of vesting accounts, allowing `NYM` tokens to vest over time, and for users to minimally interact with the Mixnet using their unvested tokens. You can find the code and build instructions [here](https://github.com/nymtech/nym/tree/release/v1.1.0/contracts/vesting). 
+
+### Functionality 
+The Vesting contract has multiple functions:
+* Creating and storing vesting `NYM` token vesting accounts.
+* Interacting with the Mixnet using vesting (i.e. non-transferable) tokens, allowing users to delegate their unvested tokens. 
+
+The addresses of deployed smart contracts can be found in the [`network-defaults`](https://github.com/nymtech/nym/blob/release/v1.1.0/common/network-defaults/src/mainnet.rs) directory of the codebase alongside other network default values.
+
+### Interacting with the contract 
+There are two ways to interact with the deployed smart contract: 
+* the `nym-cli` tool
+* the `nyxd` binary
+
+#### Nym-cli tool (recommended in most cases) 
+The `nym-cli` tool is a binary offering a simple interface for interacting with deployed smart contract (for instance, bonding and unbonding a mix node from the CLI), as well as creating and managing accounts and keypairs, sending tokens, and querying the blockchain. 
+
+Instructions on how to do so can be found on the [`nym-cli` docs page](/docs/next/nym-cli).
+
+#### Nyxd binary 
+The `nyxd` binary, although more complex to compile and use, offers the full range of commands availiable to users of CosmosSDK chains. Use this if you are (e.g.) wanting to perform more granular queries about transactions from the CLI. 
+
+You can use the instructions on how to do this on from the [`gaiad` docs page](https://hub.cosmos.network/main/delegators/delegator-guide-cli.html#querying-the-state).
+
+


### PR DESCRIPTION
Still to do:
- [x] link to `gaiad` query documentation
- [x] change link in vesting to ^ subsection
- [x] " " " mixnet to ^ subsection
- [x] add link to block explorer in `overview`
- [x] add to `/stable/`